### PR TITLE
Fixes error where json response code could not be set

### DIFF
--- a/src/view.php
+++ b/src/view.php
@@ -22,6 +22,17 @@ class view
 		}
 	}
 
+	public static function set_response_code($code){
+	    // this is a bit sloppy. Prob better to have some kind of 
+	    // a string or constant with the specific engine name to eval
+	    // against or figure some other way out of allowing you to set <thead>
+	    // the response code for json responses
+	    if(get_class(self::$engine) === view\json::class){
+		self::$engine->set_response_code( $code );
+	    }
+	}
+    
+
 	public static function title( $title = '' )
 	{
 		self::$engine->title( $title );

--- a/src/view/json.php
+++ b/src/view/json.php
@@ -44,14 +44,19 @@ class json
 
 	public function set_response_code( $response_code )
 	{
-		$this->$response_code = $response_code;
+		$this->response_code = $response_code;
 	}
+
+	public function get_response_code(){
+	    return $this->response_code;
+	}
+
 
 	public function render()
 	{
-		if( !empty($this->response_code) )
+		if( !empty($this->get_response_code()) )
 		{
-			http_response_code($this->response_code);
+			http_response_code($this->get_response_code());
 		}
 		else
 		{


### PR DESCRIPTION
I wasn't able to set the response code for a json response. I didn't want to force the response code at the controller level so I dug in to figure out why I couldn't set it at the the engine level.